### PR TITLE
refactor:url경로수정 및 서비스이용약관을 p 태그에서 ul/ol로 시맨틱 구조 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,8 @@ const AppRoutes = () => {
                 <Route path='/mypage/my-postList' element={!user ? <Login /> : <MyPostList />} />
                 <Route path='/mypage/privacy' element={!user ? <Login /> : <Privacy />} />
                 <Route path='/mypage/terms' element={!user ? <Login /> : <Terms />} />
+                <Route path='/privacy' element={<Privacy />} />
+                <Route path='/terms' element={<Terms />} />
                 <Route path='/mypage/delete-account' element={!user ? <Login /> : <DeleteAccount />} />
                 <Route path='/recipes' element={<Recipes />} />
                 <Route path='/recipes/form' element={!user ? <Login /> : <RecipeForm />} />

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -7,11 +7,11 @@ const Footer = () => {
             {/* 상단 링크 영역 */}
             <div className={styles.footer__container}>
                 <div className={styles.footer__links}>
-                    <Link to='/mypage/privacy' className='footer-link'>
-                        개인정보처리방침
+                    <Link to='/privacy' className='footer-link'>
+                        개인정보 처리방침
                     </Link>
                     <span className={styles.footer__bar}></span>
-                    <Link to='/mypage/terms' className={styles['footer-link']}>
+                    <Link to='/terms' className={styles['footer-link']}>
                         서비스이용약관
                     </Link>
                 </div>

--- a/src/pages/mypage/Mypage.tsx
+++ b/src/pages/mypage/Mypage.tsx
@@ -170,10 +170,10 @@ const Mypage = () => {
                     <Link to='/mypage/levelup-guide' className={styles.page__menu_item}>
                         모두의 레벨업 가이드
                     </Link>
-                    <Link to='/privacy' className={styles.page__menu_item}>
+                    <Link to='/mypage/privacy' className={styles.page__menu_item}>
                         개인정보 처리방침
                     </Link>
-                    <Link to='/terms' className={styles.page__menu_item}>
+                    <Link to='/mypage/terms' className={styles.page__menu_item}>
                         서비스 이용약관
                     </Link>
                     <div className={styles.page__actions}>

--- a/src/pages/mypage/Privacy.tsx
+++ b/src/pages/mypage/Privacy.tsx
@@ -5,7 +5,7 @@ import styles from './privacy.module.css';
 function Privacy() {
     const pageConfig = useMemo(
         () => ({
-            title: '개인정보처리방침',
+            title: '개인정보 처리방침',
             pageName: 'privacy',
             showBackButton: true,
         }),

--- a/src/pages/mypage/Terms.tsx
+++ b/src/pages/mypage/Terms.tsx
@@ -27,62 +27,134 @@ function Terms() {
                         합니다.
                     </p>
                     <strong className={styles.terms__sub_title}>제2조 (정의)</strong>
-                    <p className={styles.terms__text}>
-                        1. "서비스"란 회사가 제공하는 요리 레시피 공유, 검색, 평가 등의 모든 서비스를 의미합니다. 2.
-                        "이용자"란 본 약관에 따라 회사와 서비스 이용계약을 체결하고 회사가 제공하는 서비스를 이용하는
-                        자를 의미합니다. 3. "회원"이란 회사에 개인정보를 제공하여 회원등록을 한 자로서, 회사의 정보를
-                        지속적으로 제공받으며 회사가 제공하는 서비스를 계속적으로 이용할 수 있는 자를 의미합니다.
-                    </p>
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>
+                                1. "서비스"란 회사가 제공하는 요리 레시피 공유, 검색, 평가 등의 모든 서비스를
+                                의미합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                2. "이용자"란 본 약관에 따라 회사와 서비스 이용계약을 체결하고 회사가 제공하는 서비스를
+                                이용하는 자를 의미합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                3. "회원"이란 회사에 개인정보를 제공하여 회원등록을 한 자로서, 회사의 정보를 지속적으로
+                                제공받으며 회사가 제공하는 서비스를 계속적으로 이용할 수 있는 자를 의미합니다.
+                            </p>
+                        </li>
+                    </ol>
                     <strong className={styles.terms__sub_title}>제3조 (약관의 효력 및 변경)</strong>
-                    <p className={styles.terms__text}>
-                        1. 본 약관은 서비스 화면에 게시하거나 기타의 방법으로 이용자에게 공지함으로써 효력이 발생합니다.
-                        2. 회사는 필요하다고 인정되는 경우 본 약관을 변경할 수 있으며, 변경된 약관은 제1항과 같은
-                        방법으로 공지 또는 통지함으로써 효력이 발생합니다.
-                    </p>
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>
+                                1. 본 약관은 서비스 화면에 게시하거나 기타의 방법으로 이용자에게 공지함으로써 효력이
+                                발생합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                2. 회사는 필요하다고 인정되는 경우 본 약관을 변경할 수 있으며, 변경된 약관은 제1항과
+                                같은 방법으로 공지 또는 통지함으로써 효력이 발생합니다.
+                            </p>
+                        </li>
+                    </ol>
                     <strong className={styles.terms__sub_title}>제4조 (서비스의 제공)</strong>
-                    <p className={styles.terms__text}>
-                        1. 회사는 다음과 같은 서비스를 제공합니다: - 요리 레시피 작성 및 공유 - 레시피 검색 및 조회 -
-                        레시피 평가 및 댓글 - 요리 재료 정보 제공 - 기타 회사가 추가 개발하거나 다른 회사와의 제휴계약
-                        등을 통해 이용자에게 제공하는 일체의 서비스
-                    </p>
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>1. 회사는 다음과 같은 서비스를 제공합니다:</p>
+                            <ul className={styles.terms__text_sub}>
+                                <li>요리 레시피 작성 및 공유</li>
+                                <li>레시피 평가 및 댓글</li>
+                                <li>레시피 검색 및 조회</li>
+                                <li>요리 재료 정보 제공</li>
+                                <li>
+                                    기타 회사가 추가 개발하거나 다른 회사와의 제휴계약 등을 통해 이용자에게 제공하는
+                                    일체의 서비스
+                                </li>
+                            </ul>
+                        </li>
+                    </ol>
+                    <p className={styles.terms__text}></p>
                     <strong className={styles.terms__sub_title}>제5조 (서비스 이용계약의 성립)</strong>
-                    <p className={styles.terms__text}>
-                        1. 서비스 이용계약은 이용자가 본 약관에 동의하고 회원가입 신청을 하면 회사가 이를 승낙함으로써
-                        성립됩니다. 2. 회사는 다음 각 호에 해당하는 신청에 대해서는 승낙하지 않을 수 있습니다: - 실명이
-                        아니거나 타인의 명의를 이용한 경우 - 허위의 정보를 기재하거나, 회사가 제시하는 내용을 기재하지
-                        않은 경우 - 미성년자가 법정대리인의 동의를 얻지 아니한 경우
-                    </p>
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>
+                                1. 서비스 이용계약은 이용자가 본 약관에 동의하고 회원가입 신청을 하면 회사가 이를
+                                승낙함으로써 성립됩니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>2. 회사는 다음 각 호에 해당하는 신청에 대해서는 승낙하지 않을 수 있습니다:</p>
+                            <ul className={styles.terms__text_sub}>
+                                <li>실명이 아니거나 타인의 명의를 이용한 경우</li>
+                                <li>허위의 정보를 기재하거나, 회사가 제시하는 내용을 기재하지 않은 경우</li>
+                                <li>미성년자가 법정대리인의 동의를 얻지 아니한 경우</li>
+                            </ul>
+                        </li>
+                    </ol>
                     <strong className={styles.terms__sub_title}>제6조 (회원정보의 변경)</strong>
-                    <p className={styles.terms__text}>
-                        1. 회원은 개인정보관리화면을 통하여 언제든지 본인의 개인정보를 열람하고 수정할 수 있습니다. 2.
-                        회원은 회원가입 시 기재한 사항이 변경되었을 경우 온라인으로 수정을 하거나 전자우편 기타 방법으로
-                        회사에 그 변경사항을 알려야 합니다.
-                    </p>
-                    <strong className={styles.terms__sub_title}>제7조 (개인정보보호)</strong>{' '}
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>
+                                1. 회원은 개인정보관리화면을 통하여 언제든지 본인의 개인정보를 열람하고 수정할 수
+                                있습니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                2. 회원은 회원가입 시 기재한 사항이 변경되었을 경우 온라인으로 수정을 하거나 전자우편
+                                기타 방법으로 회사에 그 변경사항을 알려야 합니다.
+                            </p>
+                        </li>
+                    </ol>
+                    <strong className={styles.terms__sub_title}>제7조 (개인정보보호)</strong>
                     <p className={styles.terms__text}>
                         회사는 관련법령이 정하는 바에 따라 회원 등록정보를 포함한 회원의 개인정보를 보호하기 위해
                         노력합니다. 회원 개인정보의 보호 및 사용에 대해서는 관련법령 및 회사의 개인정보보호정책이
                         적용됩니다.
                     </p>
-                    <strong className={styles.terms__sub_title}>제8조 (이용자의 의무)</strong>{' '}
-                    <p className={styles.terms__text}>
-                        1. 이용자는 다음 행위를 하여서는 안됩니다: - 신청 또는 변경 시 허위내용의 등록 - 타인의 정보
-                        도용 - 회사가 게시한 정보의 변경 - 회사가 정한 정보 이외의 정보(컴퓨터 프로그램 등) 등의 송신
-                        또는 게시 - 회사 기타 제3자의 저작권 등 지적재산권에 대한 침해 - 회사 기타 제3자의 명예를
-                        손상시키거나 업무를 방해하는 행위 - 외설 또는 폭력적인 메시지, 화상, 음성, 기타 공서양속에
-                        반하는 정보를 회사에 공개 또는 게시하는 행위
-                    </p>
-                    <strong className={styles.terms__sub_title}>제9조 (서비스 이용제한)</strong>{' '}
+                    <strong className={styles.terms__sub_title}>제8조 (이용자의 의무)</strong>
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>1. 이용자는 다음 행위를 하여서는 안됩니다:</p>
+                            <ul className={styles.terms__text_sub}>
+                                <li>신청 또는 변경 시 허위내용의 등록</li>
+                                <li>타인의 정보 도용</li>
+                                <li>회사가 게시한 정보의 변경</li>
+                                <li>회사가 정한 정보 이외의 정보(컴퓨터 프로그램 등) 등의 송신 또는 게시</li>
+                                <li>회사 기타 제3자의 저작권 등 지적재산권에 대한 침해</li>
+                                <li>회사 기타 제3자의 명예를 손상시키거나 업무를 방해하는 행위</li>
+                                <li>
+                                    외설 또는 폭력적인 메시지, 화상, 음성, 기타 공서양속에 반하는 정보를 회사에 공개
+                                    또는 게시하는 행위
+                                </li>
+                            </ul>
+                        </li>
+                    </ol>
+                    <strong className={styles.terms__sub_title}>제9조 (서비스 이용제한)</strong>
                     <p className={styles.terms__text}>
                         회사는 이용자가 본 약관의 의무를 위반하거나 서비스의 정상적인 운영을 방해한 경우, 경고,
                         일시정지, 영구이용정지 등으로 서비스 이용을 단계적으로 제한할 수 있습니다.
                     </p>
-                    <strong className={styles.terms__sub_title}>제10조 (면책조항)</strong>{' '}
-                    <p className={styles.terms__text}>
-                        1. 회사는 천재지변 또는 이에 준하는 불가항력으로 인하여 서비스를 제공할 수 없는 경우에는 서비스
-                        제공에 관한 책임이 면제됩니다. 2. 회사는 이용자의 귀책사유로 인한 서비스 이용의 장애에 대하여는
-                        책임을 지지 않습니다.
-                    </p>
+                    <strong className={styles.terms__sub_title}>제10조 (면책조항)</strong>
+                    <ol className={styles.terms__text}>
+                        <li>
+                            <p>
+                                1. 회사는 천재지변 또는 이에 준하는 불가항력으로 인하여 서비스를 제공할 수 없는 경우에는
+                                서비스 제공에 관한 책임이 면제됩니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                2. 회사는 이용자의 귀책사유로 인한 서비스 이용의 장애에 대하여는 책임을 지지 않습니다.
+                            </p>
+                        </li>
+                    </ol>
+                    
                     <strong className={styles.terms__sub_title}>제11조 (준거법 및 관할법원)</strong>{' '}
                     <p className={styles.terms__text}>
                         본 약관에 관해서는 대한민국의 법을 적용하며, 서비스 이용으로 발생한 분쟁에 대해 소송이 제기되는

--- a/src/pages/mypage/privacy.module.css
+++ b/src/pages/mypage/privacy.module.css
@@ -25,7 +25,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: start;
-    gap: clamp(0.2rem, 0.4rem + (100vw - 390px) * 0.05, 1rem);
+    gap: clamp(0.4rem, 0.4rem + (100vw - 390px) * 0.05, 1rem);
     word-break: keep-all;
 }
 
@@ -56,7 +56,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: start;
-    gap: clamp(0.2rem, 0.4rem + (100vw - 390px) * 0.05, 1rem);
+    gap: clamp(0.4rem, 0.4rem + (100vw - 390px) * 0.05, 1rem);
 }
 .privacy__content_text > li {
     padding-left: 1.5rem;

--- a/src/pages/mypage/terms.module.css
+++ b/src/pages/mypage/terms.module.css
@@ -43,3 +43,30 @@
     font-weight: bold;
     margin-top: clamp(1.6rem, 1.6rem + (100vw - 390px) * 0.05, 2.4rem);
 }
+
+.terms__text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: start;
+    gap: clamp(0.4rem, 0.4rem + (100vw - 390px) * 0.05, 1rem);
+}
+
+.terms__text_sub {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: start;
+    gap: clamp(0.2rem, 0.2rem + (100vw - 390px) * 0.05, 0.8rem);
+    margin-top: clamp(0.2rem, 0.2rem + (100vw - 390px) * 0.05, 0.8rem);
+}
+.terms__text_sub > li {
+    padding-left: 1.5rem;
+    position: relative;
+}
+.terms__text_sub > li::after {
+    content: '-';
+    position: absolute;
+    top: 0;
+    left: 0;
+}


### PR DESCRIPTION
## 📝 작업 내용
- 경로 분리 (공통: /terms, /privacy  마이페이지: /mypage/terms , /mypage/privacy)
- 서비스이용약관을 p 태그에서 ul/ol로 시맨틱 구조 개선

## 🔧 변경사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## 📸 스크린샷 (UI 변경 시)

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인.
- [ ] 코드가 컨벤션을 따르고 있습니다.
- [ ] 불필요한 console.log를 제거했습니다.
- [x] 반응형 디자인을 확인했습니다.

## 👀 리뷰 포인트