### PR TITLE
fix: 게시물 작성, 수정, 회원정보 수정 후 뒤로가기 못하도록 변경

### DIFF
--- a/src/components/modal/ModalProvider.tsx
+++ b/src/components/modal/ModalProvider.tsx
@@ -60,7 +60,7 @@ const ModalProvider = ({ children }: { children: React.ReactNode }) => {
                 break;
             case 'SUCCESS': {
                 const data = modalState.data;
-                if (data && typeof data === 'string') navigate(data);
+                if (data && typeof data === 'string') navigate(data, { replace: true });
                 break;
             }
             case 'DELETE_ACCOUNT':

--- a/src/pages/mypage/UserEditForm.tsx
+++ b/src/pages/mypage/UserEditForm.tsx
@@ -201,18 +201,12 @@ const UserEditForm: React.FC = () => {
 
             const result = await updateUser(updateData);
 
-            // 디버깅을 위해 result 값 확인
-            console.log('updateUser result:', result, typeof result);
-
             setIsLoading(false);
 
-            if (result === false) {
+            if (!result) {
                 openModal('FAIL', undefined, '이전 비밀번호와 동일합니다.');
                 return;
-            }
-
-            // 성공 케이스 처리
-            if (result === true) {
+            } else {
                 openModal('SUCCESS', '/mypage', '회원정보가 수정되었습니다.');
                 return;
             }
@@ -392,7 +386,7 @@ const UserEditForm: React.FC = () => {
                             name='birthDate'
                             state={
                                 formData.birthDate
-                                    ? (formData.birthDate.charAt(0) === '0' ? '20' : '19') +
+                                    ? (formData.birthDate.charAt(0) <= '2' ? '20' : '19') +
                                       formData.birthDate.slice(0, 2) +
                                       '.' +
                                       formData.birthDate.slice(2, 4) +
@@ -440,7 +434,7 @@ const UserEditForm: React.FC = () => {
                                     id='korean'
                                     name='isForeigner'
                                     value='false'
-                                    checked={formData.isForeigner === false}
+                                    checked={!formData.isForeigner}
                                     isDisabled={true}
                                     handleInput={() => {}}
                                 />
@@ -449,7 +443,7 @@ const UserEditForm: React.FC = () => {
                                     id='foreigner'
                                     name='isForeigner'
                                     value='true'
-                                    checked={formData.isForeigner === true}
+                                    checked={formData.isForeigner}
                                     isDisabled={true}
                                     handleInput={() => {}}
                                 />


### PR DESCRIPTION
## 📝 작업 내용
- 게시물 등록, 수정, 회원정보 수정시 뒤로가기 막기
- 회원정보 수정 년도 계산 수정

## 🔧 변경사항
<!-- 구체적인 변경사항들을 나열해주세요 -->
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## 📸 스크린샷 (UI 변경 시)
<!-- UI 관련 변경사항이 있다면 Before/After 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인.
- [x] 코드가 컨벤션을 따르고 있습니다.
- [ x 불필요한 console.log를 제거했습니다.
- [ ] 반응형 디자인을 확인했습니다.

## 👀 리뷰 포인트
<!-- 특별히 리뷰받고 싶은 부분이 있다면 명시해주세요 -->