### PR TITLE
refactor: 전체 word-breat 설정 및 메인랭킹 line-height 설정

### DIFF
--- a/src/components/main/rank.module.css
+++ b/src/components/main/rank.module.css
@@ -82,6 +82,7 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    line-height: 125%;
 }
 .post__meta {
     align-self: center;

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -5,6 +5,7 @@ body {
 html {
     /* 기본 폰트사이즈 10px */
     font-size: 62.5%;
+    word-break: keep-all;
 }
 
 .sr-only {


### PR DESCRIPTION
## 📝 작업 내용
- 공통 css html태그에 word-breat : keep-all 설정
- rank.module.css에 메인랭킹 line-height:125% 설정

## 🔧 변경사항
<!-- 구체적인 변경사항들을 나열해주세요 -->
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## 📸 스크린샷 (UI 변경 시)
<!-- UI 관련 변경사항이 있다면 Before/After 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인.
- [ ] 코드가 컨벤션을 따르고 있습니다.
- [ ] 불필요한 console.log를 제거했습니다.
- [x] 반응형 디자인을 확인했습니다.

## 👀 리뷰 포인트
<!-- 특별히 리뷰받고 싶은 부분이 있다면 명시해주세요 -->